### PR TITLE
Fix footer component name

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 
-export default function Header() {
+export default function Footer() {
   return (
     <section id="footer">
       <i></i>


### PR DESCRIPTION
## Summary
- fix Footer component name so the display name matches its role

## Testing
- `pnpm lint`
- `pnpm exec tsc --noEmit`
- `pnpm build`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_683fbf09f7188327892a6761bc167180)